### PR TITLE
Using request headers for passing the auth token

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,23 @@ For example, you can make the following call from inside any controller:
 Auth.ajax('/api/non_standard_route', POST, {})
 ```
 
+### Request headers
+
+You can also use a request header instead of a parameter to send the auth token 
+with each authenticated request. There are two configuration parameters that 
+need to be set to enable this:
+
+```coffeescript
+Auth.Config.reopen
+  requestHeaderAuthorization: true
+  requestHeaderKey: 'X-API-TOKEN'
+```
+
+Using this configuration the auth token will automatically be sent using a 
+request header instead of a param. 
+
+E.g. headers { "X-API-TOKEN": Auth.get('authToken') }
+
 ## Authenticated-only routes
 
 Authenticated-only routes setup: you will use `Auth.Route`; it is an

--- a/src/auth.coffee
+++ b/src/auth.coffee
@@ -122,8 +122,12 @@ window.Auth = evented.create
 
   ajax: (url, type, hash) ->
     if token = @get('authToken')
-      hash.data ||= {}
-      hash.data[Auth.Config.get('tokenKey')] = @get('authToken')
+      if Auth.Config.get('requestHeaderAuthorization')
+        hash.headers ||= {}
+        hash.headers['Authorization'] = 'token ' + @get('authToken')
+      else
+        hash.data ||= {}
+        hash.data[Auth.Config.get('tokenKey')] = @get('authToken')
       
     hash.url         = url
     hash.type        = type

--- a/src/auth.coffee
+++ b/src/auth.coffee
@@ -124,7 +124,7 @@ window.Auth = evented.create
     if token = @get('authToken')
       if Auth.Config.get('requestHeaderAuthorization')
         hash.headers ||= {}
-        hash.headers['Authorization'] = 'token ' + @get('authToken')
+        hash.headers[Auth.Config.get('requestHeaderKey')] = @get('authToken')
       else
         hash.data ||= {}
         hash.data[Auth.Config.get('tokenKey')] = @get('authToken')

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -53,6 +53,13 @@ Auth.Config = Em.Object.create
   # If this hook returns true, the auth token will be passed in the request 
   # header instead the data hash.
   requestHeaderAuthorization: false
+  
+  # You must implement this hook if requestHeaderAuthorization returns true:
+  # It should return the name of the header to use for sending the auth token.
+  # e.g. 
+  #   if you set this to 'X-API-TOKEN' a header will automatically be sent with 
+  #   each request: headers { "X-API-TOKEN": Auth.get('authToken') }
+  requestHeaderKey: null
 
   # =====================
   # Redirection config

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -49,6 +49,10 @@ Auth.Config = Em.Object.create
   #   but your ember application lives at http://example.com/,
   #   then set this to 'http://api.example.com'
   baseUrl: null
+  
+  # If this hook returns true, the auth token will be passed in the request 
+  # header instead the data hash.
+  requestHeaderAuthorization: false
 
   # =====================
   # Redirection config


### PR DESCRIPTION
This PR allows an optional configuration to use request headers to pass the auth token instead of a param. This is the way oauth works. Its a bit cleaner and was a requirement for my application. May be useful for others as well. The default is to use params, if you do not set the optional parameters there is no change in functionality.
