### PR TITLE
Controllers can route via transitionToRoute

### DIFF
--- a/src/controllers/sign-in.coffee
+++ b/src/controllers/sign-in.coffee
@@ -4,5 +4,5 @@ Auth.SignInController = Em.ObjectController.extend
 
   smartSignInRedirect: ->
     if Auth.get('authToken')
-      @get('target.router').transitionTo Auth.resolveRedirectRoute('signIn')
+      @transitionToRoute Auth.resolveRedirectRoute('signIn')
       Auth.removeObserver 'authToken', this, 'smartSignInRedirect'

--- a/src/controllers/sign-out.coffee
+++ b/src/controllers/sign-out.coffee
@@ -4,5 +4,5 @@ Auth.SignOutController = Em.ObjectController.extend
 
   smartSignOutRedirect: ->
     if !Auth.get('authToken')
-      @get('target.router').transitionTo Auth.resolveRedirectRoute('signOut')
+      @transitionToRoute Auth.resolveRedirectRoute('signOut')
       Auth.removeObserver 'authToken', this, 'smartSignOutRedirect'


### PR DESCRIPTION
Instead of using a @get('target.router') you can directly transition via @transitionToRoute ...
