### PR TITLE
jquery.cookie.js is not required if using localStorage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,6 +516,8 @@ Auth.Config.reopen
   rememberStorage: 'localStorage' # defaults to 'cookie'
 ```
 
+If you choose to use localStorage you can remove the jquery.cookie.js library from the distributed js file.
+
 Remember Me will (attempt to) auto-sign in the user from the local cookie
 when the user accesses an `Auth.Route` (only if one is not already signed in).
 If you want to implement this behavior elsewhere, set `rememberAutoRecall` to


### PR DESCRIPTION
Add a note to the README about jquery.cookie.js not being required. (I'm becoming a stickler for keeping as few dependencies around as possible :))
