### PR TITLE
adding remember-me to url-authentication

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -24,6 +24,14 @@ Auth.Config = Em.Object.create
   #   if POST /api/token returns {auth_token: "fjlja8hfhf4"},
   #   set this to 'auth_token'
   tokenKey: null
+  
+  # REQUIRED
+  # You must implement this hook:
+  # It should return the name of the key of auth token in your API's response.
+  # e.g.
+  #   if POST /api/token returns {remember: true},
+  #   set this to true
+  rememberKey: null
 
   # REQUIRED
   # You must implement this hook:
@@ -156,8 +164,12 @@ Auth.Config = Em.Object.create
   # the route will check for the token passed in as a query parameter and use
   # it to authenticate before redirecting. A common use case for this is 
   # automatically authenticating a user from a link in a system generated email.
+  # Another common case is returning from Oauth authentication once the identity
+  # provider has confirmed identity and authorized the request.
   #
-  # The name of the URL parameter is defined by the Auth.Config.tokenKey hook. 
+  # The name of the URL parameter is defined by the Auth.Config.tokenKey hook.
+  # It is also possible to sign in with remember me enabled. The name of the 
+  # additional URL parameter is defined by Auth.Config.rememberKey
   #
   # Along with the regular set of sign in credentials, your token creation API 
   # end point should also accept the token itself.
@@ -167,6 +179,11 @@ Auth.Config = Em.Object.create
   #   and Auth.Config.tokenKey returns 'auth_token' 
   #   then a URL containing ?auth_token=fjlja8hfhf4
   #   will POST /api/sign_in { "auth_token": "fjlja8hfhf4" }
+  #
+  # e.g.2.
+  #   if besides the previous example, Auth.Config.rememberKey returns 'remember'
+  #   a URL containing ?auth_token=fjlja8hfhf4&remember=true
+  #   will POST /api/sign_in { "auth_token": "fjlja8hfhf4", "remember": true }
   #
   # Until Ember supports query parameters the parameter must exist before the 
   # Ember route hash.

--- a/lib/modules/url-authentication.coffee
+++ b/lib/modules/url-authentication.coffee
@@ -9,6 +9,8 @@ Auth.Module.UrlAuthentication = Em.Object.create
       data = {}
       data['async'] = opts.async if opts.async?
       data[Auth.Config.get('tokenKey')] = token
+      if remember = @retrieveRemember()
+        data[Auth.Config.get('rememberKey')] = true
       Auth.signIn data
 
   retrieveToken: ->
@@ -16,3 +18,7 @@ Auth.Module.UrlAuthentication = Em.Object.create
     # Remove trailing slash
     token = token.slice(0, -1) if token && token.charAt(token.length-1) is '/'
     token
+
+  retrieveRemember: ->
+    remember = $.url().param(Auth.Config.get('rememberKey'))
+    remember


### PR DESCRIPTION
I think the url-authentication feature is very useful and I've started using it for Omniauth authentication.

It would be very useful if url-authentication allowed remember-me because I think it is more natural for Oauth users not having to authenticate each time and also because in this way, the page can be reloaded if needed and one can possibly get rid of the auth token on the url which is a security concern.

I'm very sorry that I haven't tested this feature because I get this message when I try to run the application to test: `raise_if_conflicts': Unable to activate ember-source-0.0.5, because handlebars-source-1.0.9 conflicts with handlebars-source (< 1.0.0.rc4, >= 1.0.0.rc3) (Gem::LoadError) Maybe I'm not doing what is needed to test.
