### PR TITLE
Ember-model custom adapter support

### DIFF
--- a/lib/module/ember-model.em
+++ b/lib/module/ember-model.em
@@ -1,10 +1,14 @@
 class Em.Auth.Module.EmberModel
-  init: -> @patch()
+  init: ->
+      @config? || (@config = @auth.emberModel || {})
+      @config.adapter? || (@config.adapter = 'Ember.RESTAdapter')
+      @patch()
 
   patch: ->
+    adapter = Ember.get @config.adapter
     self = this
-    if Ember.RESTAdapter?
-      Ember.RESTAdapter.reopen
+    if adapter?
+      adapter.reopen
         _ajax: (url, params, method) ->
           settings = this.ajaxSettings url, method
           new Ember.RSVP.Promise (resolve, reject) ->

--- a/spec/javascripts/module/ember-model-spec.em
+++ b/spec/javascripts/module/ember-model-spec.em
@@ -15,3 +15,8 @@ describe 'Em.Auth.Module.EmberModel', ->
         adapter = Ember.RESTAdapter.create()
         adapter.ajax '/foo'
       expect(spy).toHaveBeenCalled()
+
+  describe 'default adapter', ->
+    it 'defaults to Ember.RESTAdapter', ->
+      adapter = auth.module.emberModel.config.adapter
+      expect(adapter).toEqual 'Ember.RESTAdapter'


### PR DESCRIPTION
I implemented a config option which allows users to put a specified `RESTAdapter` in place of the default `Ember.RESTAdapter`. An example config looks like this:

``` coffeescript
App.Auth = Ember.Auth.create
  # ...
  emberModel:
    adapter: 'App.RESTAdapter'
```

I've attached a test case which checks if the emberModel.adapter option defaults to `Ember.RESTAdapter' so that this patch doesn't break backward compatibility, but I'm not sure what's a good way to test if a custom adapter is actually working.

P.S. I guess we can do the same thing in the ember-data module.
