### PR TITLE
Do not stringify settings.data in ember-model module

### DIFF
--- a/lib/module/ember-model.em
+++ b/lib/module/ember-model.em
@@ -9,11 +9,12 @@ class Em.Auth.Module.EmberModel
           settings = this.ajaxSettings url, method
           new Ember.RSVP.Promise (resolve, reject) ->
             if params
-              if method is "GET"
-                settings.data = params
-              else
+              # settings.data needs to be an object rather than a string
+              # regardless of the method. It's going to be stringified
+              # in Em.Auth.Request.Jquery#send if needed.
+              settings.data = params
+              unless method is "GET"
                 settings.contentType = "application/json; charset=utf-8"
-                settings.data = JSON.stringify params
             settings.success = (json)  -> Ember.run null, resolve, json
             settings.error   = (jqxhr) -> Ember.run null, reject, jqxhr
             self.auth._request.send settings


### PR DESCRIPTION
This is a fix for #78. I haven't been able to use this code anywhere. So if anyone could try it, that would be great.
