### PR TITLE
Dont set contentType in Ember-Model module

### DIFF
--- a/lib/module/ember-model.em
+++ b/lib/module/ember-model.em
@@ -11,10 +11,9 @@ class Em.Auth.Module.EmberModel
             if params
               # settings.data needs to be an object rather than a string
               # regardless of the method. It's going to be stringified
-              # in Em.Auth.Request.Jquery#send if needed.
+              # and contentType will be set in Em.Auth.Request.Jquery#send 
+              # if needed.
               settings.data = params
-              unless method is "GET"
-                settings.contentType = "application/json; charset=utf-8"
             settings.success = (json)  -> Ember.run null, resolve, json
             settings.error   = (jqxhr) -> Ember.run null, reject, jqxhr
             self.auth._request.send settings

--- a/lib/module/ember-model.em
+++ b/lib/module/ember-model.em
@@ -9,11 +9,12 @@ class Em.Auth.Module.EmberModel
           settings = this.ajaxSettings url, method
           new Ember.RSVP.Promise (resolve, reject) ->
             if params
-              if method is "GET"
-                settings.data = params
-              else
+              # settings.data needs to be an object rather than a string
+              # regardless of the method. It's going to be stringified
+              # in Em.Auth.Request.Jquery#send if needed.
+              settings.data = params
+              unless method is "GET"
                 settings.contentType = "application/json; charset=utf-8"
-                settings.data = JSON.stringify params
             settings.success = (json)  -> Ember.run null, resolve, json
             settings.error   = (jqxhr) -> Ember.run null, reject, jqxhr
             self.auth._request.send settings


### PR DESCRIPTION
Update to #94 PR to fix the bug reported in #78. We shouldn't need to set the contentType in Em.Auth.Module.EmberModel since Em.Auth.Request.Jquery#send already does this for us. 
