### PR TITLE
adding data config value

### DIFF
--- a/dist/ember-auth.js
+++ b/dist/ember-auth.js
@@ -78,6 +78,8 @@ void function () {
         url = get$(this, '_request').resolveUrl(url);
       }
       opts || (opts = {});
+      opts.data || (opts.data = {});
+      set$(opts, 'data', $.extend(true, get$(this, 'data'), get$(opts, 'data')));
       return new (get$(get$(Em, 'RSVP'), 'Promise'))((this$ = this, function (resolve, reject) {
         var this$1, this$2;
         return get$(this$, '_request').signIn(url, get$(this$, '_strategy').serialize(opts)).then((this$1 = this$, function (response) {
@@ -164,6 +166,8 @@ void function () {
         url = get$(this, '_request').resolveUrl(url);
       }
       opts || (opts = {});
+      opts.data || (opts.data = {});
+      set$(opts, 'data', $.extend(true, get$(this, 'data'), get$(opts, 'data')));
       return new (get$(get$(Em, 'RSVP'), 'Promise'))((this$ = this, function (resolve, reject) {
         var this$1, this$2;
         return get$(this$, '_request').send(url, get$(this$, '_strategy').serialize(opts)).then((this$1 = this$, function (response) {
@@ -365,5 +369,6 @@ get$(Em, 'Auth').reopen({
   modules: [],
   signInEndPoint: null,
   signOutEndPoint: null,
-  baseUrl: null
+  baseUrl: null,
+  data: {}
 });

--- a/lib/auth.em
+++ b/lib/auth.em
@@ -67,6 +67,8 @@ class Em.Auth
     else
       url  = @_request.resolveUrl url
     opts ||= {}
+    opts.data ||= {}
+    opts.data = $.extend true, @data, opts.data
 
     new Em.RSVP.Promise (resolve, reject) =>
       @_request.signIn(url, @_strategy.serialize(opts))
@@ -145,6 +147,8 @@ class Em.Auth
     else
       url  = @_request.resolveUrl url
     opts ||= {}
+    opts.data ||= {}
+    opts.data = $.extend true, @data, opts.data
 
     new Em.RSVP.Promise (resolve, reject) =>
       @_request.send(url, @_strategy.serialize(opts))

--- a/lib/config.em
+++ b/lib/config.em
@@ -27,3 +27,6 @@ Em.Auth.reopen
 
   # [string|null] (opt) a different base url for all ember-auth requests
   baseUrl: null
+
+  # static data to send with every request
+  data: {}


### PR DESCRIPTION
data to tack on each signIn and send request.

  data: { grant_type: 'password' }

for use with web api oauth default implementations
